### PR TITLE
Json event refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Superfetch-js
+# Shebang-js
 
 A hypertext extension for the browser.
 
@@ -24,7 +24,7 @@ npm install https://github.com/wolfpup-software/superfetch-js
 Add a `host` and some `eventNames` on instantiation.
 
 ```ts
-let superfetch = new Superfetch({
+let bang = new Bang({
 	host: document,
 	connected: true,
 	eventNames: ["click", "pointerover"],
@@ -50,14 +50,6 @@ Super chunk can fetch esmodules using the following syntax:
 ></button>
 ```
 
-Then add an event listener for an `#esmodule` event
-
-```ts
-document.addEventListener("#esmodule", e: EsModuleEvent) {
-	console.log(e.results) // { url, status }
-}
-```
-
 ## JSON
 
 Super chunk can fetch and dispatch JSON using the following syntax:
@@ -78,7 +70,9 @@ Super chunk can fetch html using the following syntax:
 	click:="html"
 	click:url="/fetch/some.html"
 	click:projection="swap"
+	click:match="_parent"
 	click:querySelector="ul"
+	click:querySelectorAll="[profile=fri490r]"
 ></button>
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ A hypertext extension for the browser.
 
 ## About
 
-`Superchunk` enables a browser to declaratively:
+Superchunk is a alternative to bulky frontend frameworks and enables a browser to declaratively:
 
 - query JSON APIs
 - fetch html fragments
 - lazy-load esmodules
-- dispatch action events
-
-I got tired of using weighty frameworks just to fetch some JSON or HTML on a click.
+- dispatch action events (think redux actions)
 
 ## Install
 
@@ -24,7 +22,7 @@ npm install https://github.com/wolfpup-software/superfetch-js
 Add a `host` and some `eventNames` on instantiation.
 
 ```ts
-let bang = new Bang({
+let bang = new Superfetch({
 	host: document,
 	connected: true,
 	eventNames: ["click", "pointerover"],
@@ -69,7 +67,7 @@ Super chunk can fetch html using the following syntax:
 <button
 	click:="html"
 	click:url="/fetch/some.html"
-	click:projection="swap"
+	click:projection="replace"
 	click:match="_parent"
 	click:querySelector="ul"
 	click:querySelectorAll="[profile=fri490r]"

--- a/dist/action_event.d.ts
+++ b/dist/action_event.d.ts
@@ -2,6 +2,7 @@ import type { DispatchParams } from "./type_flyweight.js";
 export interface ActionEventParamsInterface {
     sourceEvent: Event;
     action: string;
+    formData?: FormData;
 }
 export interface ActionEventInterface {
     readonly actionParams: ActionEventParamsInterface;

--- a/dist/dispatch.js
+++ b/dist/dispatch.js
@@ -22,9 +22,9 @@ function dispatchEvent(params) {
     let attr = el.getAttribute(`${sourceEvent.type}:`);
     if ("esmodule" === attr)
         return dispatchModuleImport(params);
-    if ("html" === attr)
-        return dispatchHtmlEvent(params);
     if ("json" === attr)
         return dispatchJsonEvent(params);
+    if ("html" === attr)
+        return dispatchHtmlEvent(params);
     return dispatchActionEvent(params);
 }

--- a/dist/esmodule_event.d.ts
+++ b/dist/esmodule_event.d.ts
@@ -1,20 +1,24 @@
 import type { DispatchParams } from "./type_flyweight.js";
-interface EsModuleEventErrorStatusInterface {
+interface EsModuleEventErrorStateInterface {
     status: "rejected";
     url: string;
     error: any;
 }
-interface EsModuleEventResultsInterface {
-    status: "requested" | "resolved";
+interface EsModuleEventRequestedInterface {
+    status: "requested";
     url: string;
 }
-export type EsModuleRequestStatusInterface = EsModuleEventResultsInterface | EsModuleEventErrorStatusInterface;
+interface EsModuleEventResolvedInterface {
+    status: "resolved";
+    url: string;
+}
+export type EsModuleRequestState = EsModuleEventRequestedInterface | EsModuleEventResolvedInterface | EsModuleEventErrorStateInterface;
 export interface EsModuleEventInterface {
-    requestStatus: EsModuleRequestStatusInterface;
+    requestState: EsModuleRequestState;
 }
 export declare class ESModuleEvent extends Event implements EsModuleEventInterface {
-    requestStatus: EsModuleRequestStatusInterface;
-    constructor(requestStatus: EsModuleRequestStatusInterface, eventInitDict: EventInit);
+    requestState: EsModuleRequestState;
+    constructor(requestState: EsModuleRequestState, eventInitDict: EventInit);
 }
 export declare function dispatchModuleImport(params: DispatchParams): void;
 export {};

--- a/dist/esmodule_event.d.ts
+++ b/dist/esmodule_event.d.ts
@@ -1,13 +1,20 @@
-import type { DispatchParams, RequestStatus } from "./type_flyweight.js";
-export interface EsModuleEventResultsInterface {
+import type { DispatchParams } from "./type_flyweight.js";
+interface EsModuleEventErrorStatusInterface {
+    status: "rejected";
     url: string;
-    status: RequestStatus;
+    error: any;
 }
+interface EsModuleEventResultsInterface {
+    status: "requested" | "resolved";
+    url: string;
+}
+export type EsModuleRequestStatusInterface = EsModuleEventResultsInterface | EsModuleEventErrorStatusInterface;
 export interface EsModuleEventInterface {
-    results: EsModuleEventResultsInterface;
+    requestStatus: EsModuleRequestStatusInterface;
 }
 export declare class ESModuleEvent extends Event implements EsModuleEventInterface {
-    results: EsModuleEventResultsInterface;
-    constructor(results: EsModuleEventResultsInterface, eventInitDict: EventInit);
+    requestStatus: EsModuleRequestStatusInterface;
+    constructor(requestStatus: EsModuleRequestStatusInterface, eventInitDict: EventInit);
 }
 export declare function dispatchModuleImport(params: DispatchParams): void;
+export {};

--- a/dist/esmodule_event.d.ts
+++ b/dist/esmodule_event.d.ts
@@ -1,9 +1,4 @@
 import type { DispatchParams } from "./type_flyweight.js";
-interface EsModuleEventErrorStateInterface {
-    status: "rejected";
-    url: string;
-    error: any;
-}
 interface EsModuleEventRequestedInterface {
     status: "requested";
     url: string;
@@ -11,6 +6,11 @@ interface EsModuleEventRequestedInterface {
 interface EsModuleEventResolvedInterface {
     status: "resolved";
     url: string;
+}
+interface EsModuleEventErrorStateInterface {
+    status: "rejected";
+    url: string;
+    error: any;
 }
 export type EsModuleRequestState = EsModuleEventRequestedInterface | EsModuleEventResolvedInterface | EsModuleEventErrorStateInterface;
 export interface EsModuleEventInterface {

--- a/dist/esmodule_event.js
+++ b/dist/esmodule_event.js
@@ -1,10 +1,10 @@
 let urlSet = new Set();
 const eventInitDict = { bubbles: true, composed: true };
 export class ESModuleEvent extends Event {
-    results;
-    constructor(results, eventInitDict) {
+    requestStatus;
+    constructor(requestStatus, eventInitDict) {
         super("#esmodule", eventInitDict);
-        this.results = results;
+        this.requestStatus = requestStatus;
     }
 }
 export function dispatchModuleImport(params) {
@@ -16,18 +16,17 @@ export function dispatchModuleImport(params) {
     if (urlSet.has(url))
         return;
     urlSet.add(url);
-    dispatchEvent({ url, status: "requested" });
+    dispatchEvent({ status: "requested", url });
     import(url)
         .then(function () {
-        dispatchEvent({ url, status: "resolved" });
+        dispatchEvent({ status: "resolved", url });
     })
-        .catch(function () {
+        .catch(function (error) {
         urlSet.delete(url);
-        dispatchEvent({ url, status: "rejected" });
+        dispatchEvent({ status: "rejected", url, error });
     });
 }
-function dispatchEvent(results) {
-    let event = new ESModuleEvent(results, eventInitDict);
-    // only dispatch esmodule events from the document
+function dispatchEvent(status) {
+    let event = new ESModuleEvent(status, eventInitDict);
     document.dispatchEvent(event);
 }

--- a/dist/esmodule_event.js
+++ b/dist/esmodule_event.js
@@ -1,10 +1,10 @@
 let urlSet = new Set();
 const eventInitDict = { bubbles: true, composed: true };
 export class ESModuleEvent extends Event {
-    requestStatus;
-    constructor(requestStatus, eventInitDict) {
+    requestState;
+    constructor(requestState, eventInitDict) {
         super("#esmodule", eventInitDict);
-        this.requestStatus = requestStatus;
+        this.requestState = requestState;
     }
 }
 export function dispatchModuleImport(params) {

--- a/dist/html_event.d.ts
+++ b/dist/html_event.d.ts
@@ -4,9 +4,6 @@ export interface HtmlEventParamsInterface {
     html: string;
     disconnected?: Element[];
     connected?: Element[];
-    target?: Element;
-    destination?: Element;
-    projection?: string;
 }
 export interface HtmlEventInterface {
     readonly htmlParams: HtmlEventParamsInterface;

--- a/dist/html_event.js
+++ b/dist/html_event.js
@@ -20,6 +20,16 @@ export class HtmlEvent extends Event {
 // projection-selector="ul"
 // status-target="match | querySelector | querySelectorAll" | default is querySelector
 // status-selector="selector" pending | completed
+// get html params implements throttle params
+/*
+    {
+        html as text,
+        fragment as DomFragment,
+        targetElements: Element[],
+        projection: "swap",
+        disconnected: [],
+    }
+*/
 export function dispatchHtmlEvent(dispatchParams) {
     let requestParams = getRequestParams(dispatchParams);
     if (!requestParams)

--- a/dist/html_event.js
+++ b/dist/html_event.js
@@ -2,7 +2,7 @@
 // queue-able
 import { getRequestParams } from "./type_flyweight.js";
 import { setThrottler, getThrottleParams, shouldThrottle } from "./throttle.js";
-import { shouldQueue, enqueue } from "./queue.js";
+import { getQueueParams, enqueue } from "./queue.js";
 const eventInitDict = { bubbles: true, composed: true };
 export class HtmlEvent extends Event {
     #status;
@@ -40,7 +40,7 @@ export function dispatchHtmlEvent(dispatchParams) {
     let abortController = new AbortController();
     if (throttleParams)
         setThrottler(dispatchParams, requestParams, throttleParams, abortController);
-    let queueTarget = shouldQueue(dispatchParams);
+    let queueTarget = getQueueParams(dispatchParams);
     if (queueTarget) {
         let entry = new QueueableHtml(dispatchParams, requestParams, abortController);
         return enqueue(queueTarget, entry);

--- a/dist/json_event.d.ts
+++ b/dist/json_event.d.ts
@@ -1,18 +1,18 @@
 import type { DispatchParams, RequestStatus } from "./type_flyweight.js";
 export interface JsonEventParamsInterface {
+    status: RequestStatus;
     request: Request;
+    action: string | null;
     response?: Response;
     json?: any;
-    action?: string | null;
     error?: any;
 }
-export interface JsonEventInterface {
-    readonly jsonParams: JsonEventParamsInterface;
+export interface EsModuleEventInterface {
+    results: JsonEventParamsInterface;
 }
-export declare class JsonEvent extends Event {
-    #private;
-    constructor(params: JsonEventParamsInterface | undefined, status: RequestStatus, eventInit?: EventInit);
-    get status(): RequestStatus;
-    get json(): any | undefined;
+export declare class JsonEvent extends Event implements EsModuleEventInterface {
+    params: JsonEventParamsInterface;
+    constructor(params: JsonEventParamsInterface, eventInit?: EventInit);
+    get results(): JsonEventParamsInterface;
 }
 export declare function dispatchJsonEvent(dispatchParams: DispatchParams): void;

--- a/dist/json_event.d.ts
+++ b/dist/json_event.d.ts
@@ -7,10 +7,10 @@ export interface JsonEventParamsInterface {
     json?: any;
     error?: any;
 }
-export interface EsModuleEventInterface {
+export interface JsonEventInterface {
     results: JsonEventParamsInterface;
 }
-export declare class JsonEvent extends Event implements EsModuleEventInterface {
+export declare class JsonEvent extends Event implements JsonEventInterface {
     results: JsonEventParamsInterface;
     constructor(results: JsonEventParamsInterface, eventInit?: EventInit);
 }

--- a/dist/json_event.d.ts
+++ b/dist/json_event.d.ts
@@ -11,8 +11,7 @@ export interface EsModuleEventInterface {
     results: JsonEventParamsInterface;
 }
 export declare class JsonEvent extends Event implements EsModuleEventInterface {
-    params: JsonEventParamsInterface;
-    constructor(params: JsonEventParamsInterface, eventInit?: EventInit);
-    get results(): JsonEventParamsInterface;
+    results: JsonEventParamsInterface;
+    constructor(results: JsonEventParamsInterface, eventInit?: EventInit);
 }
 export declare function dispatchJsonEvent(dispatchParams: DispatchParams): void;

--- a/dist/json_event.d.ts
+++ b/dist/json_event.d.ts
@@ -1,17 +1,28 @@
-import type { DispatchParams, RequestStatus } from "./type_flyweight.js";
-export interface JsonEventParamsInterface {
-    status: RequestStatus;
+import type { DispatchParams } from "./type_flyweight.js";
+interface JsonEventParamsInterface {
     request: Request;
+    url: string;
     action: string | null;
-    response?: Response;
-    json?: any;
-    error?: any;
 }
+interface JsonEventRequestedInterface extends JsonEventParamsInterface {
+    status: "requested";
+}
+interface JsonEventResolvedInterface extends JsonEventParamsInterface {
+    status: "resolved";
+    response: Response;
+    json: any;
+}
+interface JsonEventRejectedInterface extends JsonEventParamsInterface {
+    status: "rejected";
+    error: any;
+}
+type JsonEventStates = JsonEventRejectedInterface | JsonEventRequestedInterface | JsonEventResolvedInterface;
 export interface JsonEventInterface {
-    results: JsonEventParamsInterface;
+    results: JsonEventStates;
 }
 export declare class JsonEvent extends Event implements JsonEventInterface {
-    results: JsonEventParamsInterface;
-    constructor(results: JsonEventParamsInterface, eventInit?: EventInit);
+    results: JsonEventStates;
+    constructor(results: JsonEventStates, eventInitDict?: EventInit);
 }
 export declare function dispatchJsonEvent(dispatchParams: DispatchParams): void;
+export {};

--- a/dist/json_event.d.ts
+++ b/dist/json_event.d.ts
@@ -16,13 +16,13 @@ interface JsonEventRejectedInterface extends JsonEventParamsInterface {
     status: "rejected";
     error: any;
 }
-type JsonEventStates = JsonEventRejectedInterface | JsonEventRequestedInterface | JsonEventResolvedInterface;
+type JsonEventState = JsonEventRejectedInterface | JsonEventRequestedInterface | JsonEventResolvedInterface;
 export interface JsonEventInterface {
-    results: JsonEventStates;
+    requestState: JsonEventState;
 }
 export declare class JsonEvent extends Event implements JsonEventInterface {
-    results: JsonEventStates;
-    constructor(results: JsonEventStates, eventInitDict?: EventInit);
+    requestState: JsonEventState;
+    constructor(requestState: JsonEventState, eventInitDict?: EventInit);
 }
 export declare function dispatchJsonEvent(dispatchParams: DispatchParams): void;
 export {};

--- a/dist/json_event.js
+++ b/dist/json_event.js
@@ -6,13 +6,10 @@ import { setThrottler, getThrottleParams, shouldThrottle } from "./throttle.js";
 import { shouldQueue, enqueue } from "./queue.js";
 const eventInitDict = { bubbles: true, composed: true };
 export class JsonEvent extends Event {
-    params;
-    constructor(params, eventInit) {
+    results;
+    constructor(results, eventInit) {
         super("#json", eventInit);
-        this.params = params;
-    }
-    get results() {
-        return this.params;
+        this.results = results;
     }
 }
 export function dispatchJsonEvent(dispatchParams) {

--- a/dist/json_event.js
+++ b/dist/json_event.js
@@ -3,10 +3,10 @@ import { setThrottler, getThrottleParams, shouldThrottle } from "./throttle.js";
 import { shouldQueue, enqueue } from "./queue.js";
 const eventInitDict = { bubbles: true, composed: true };
 export class JsonEvent extends Event {
-    results;
-    constructor(results, eventInitDict) {
+    requestState;
+    constructor(requestState, eventInitDict) {
         super("#json", eventInitDict);
-        this.results = results;
+        this.requestState = requestState;
     }
 }
 export function dispatchJsonEvent(dispatchParams) {

--- a/dist/mod.d.ts
+++ b/dist/mod.d.ts
@@ -3,7 +3,7 @@ export { ESModuleEvent } from "./esmodule_event.js";
 export { JsonEvent } from "./json_event.js";
 export { HtmlEvent } from "./html_event.js";
 export interface SuperChunkParamsInterface {
-    host: ParentNode;
+    target: ParentNode;
     eventNames: string[];
     connected?: boolean;
 }

--- a/dist/mod.js
+++ b/dist/mod.js
@@ -11,15 +11,15 @@ export class SuperChunk {
             this.connect();
     }
     connect() {
-        let { host, eventNames } = this.#params;
+        let { target, eventNames } = this.#params;
         for (let name of eventNames) {
-            host.addEventListener(name, dispatch);
+            target.addEventListener(name, dispatch);
         }
     }
     disconnect() {
-        let { host, eventNames } = this.#params;
+        let { target, eventNames } = this.#params;
         for (let name of eventNames) {
-            host.removeEventListener(name, dispatch);
+            target.removeEventListener(name, dispatch);
         }
     }
 }

--- a/dist/queue.d.ts
+++ b/dist/queue.d.ts
@@ -1,9 +1,12 @@
 import type { DispatchParams } from "./type_flyweight.js";
+export interface QueueParamsInterface {
+    queueTarget: Element;
+}
 export interface QueueNextCallback {
     (el: Element): void;
 }
 export interface Queuable {
     dispatch(cb: QueueNextCallback): void;
 }
-export declare function enqueue(el: EventTarget, queueEntry: Queuable): void;
-export declare function shouldQueue(dispatchParams: DispatchParams): EventTarget | undefined;
+export declare function enqueue(params: QueueParamsInterface, queueEntry: Queuable): void;
+export declare function getQueueParams(dispatchParams: DispatchParams): QueueParamsInterface | undefined;

--- a/dist/queue.js
+++ b/dist/queue.js
@@ -1,8 +1,9 @@
 let queueMap = new WeakMap();
 // can combine these
-export function enqueue(el, queueEntry) {
+export function enqueue(params, queueEntry) {
+    let { queueTarget } = params;
     // add function to queue
-    let queue = queueMap.get(el);
+    let queue = queueMap.get(queueTarget);
     if ("enqueued" === queue?.status) {
         queue.incoming.push(queueEntry);
         return;
@@ -12,7 +13,7 @@ export function enqueue(el, queueEntry) {
         incoming: [],
         outgoing: [],
     };
-    queueMap.set(el, freshQueue);
+    queueMap.set(queueTarget, freshQueue);
     queueEntry.dispatch(queueNext);
 }
 function queueNext(el) {
@@ -28,14 +29,14 @@ function queueNext(el) {
     }
     queue.outgoing.pop()?.dispatch(queueNext);
 }
-export function shouldQueue(dispatchParams) {
+export function getQueueParams(dispatchParams) {
     let { el, currentTarget, sourceEvent } = dispatchParams;
     let queueTarget = el.getAttribute(`${sourceEvent.type}:queue`);
     if (queueTarget) {
         // throttle by element
         if ("_target" === queueTarget)
-            return el;
-        if (currentTarget && "_currentTarget" === queueTarget)
-            return currentTarget;
+            return { queueTarget: el };
+        if (currentTarget instanceof Element && "_currentTarget" === queueTarget)
+            return { queueTarget: currentTarget };
     }
 }

--- a/dist/throttle.d.ts
+++ b/dist/throttle.d.ts
@@ -4,7 +4,7 @@ interface ThrottleParams {
     throttle: string;
     timeoutMs: number;
 }
-interface ThrottleRequestParams {
+export interface ThrottleRequestParams {
     url?: ReturnType<Element["getAttribute"]>;
     action?: ReturnType<Element["getAttribute"]>;
 }

--- a/dist/type_flyweight.d.ts
+++ b/dist/type_flyweight.d.ts
@@ -8,9 +8,9 @@ export interface ActionParams {
     action?: ReturnType<Element["getAttribute"]>;
 }
 export interface RequestParams extends ActionParams {
-    action?: ReturnType<Element["getAttribute"]>;
-    url?: ReturnType<Element["getAttribute"]>;
-    method?: ReturnType<Element["getAttribute"]>;
+    action: ReturnType<Element["getAttribute"]>;
+    url: ReturnType<Element["getAttribute"]>;
+    method: ReturnType<Element["getAttribute"]>;
     timeoutMs?: number;
 }
 export type RequestStatus = "requested" | "resolved" | "rejected";

--- a/examples/hypertext/mod.js
+++ b/examples/hypertext/mod.js
@@ -6,7 +6,7 @@ const _superChunk = new SuperChunk({
 });
 document.addEventListener("#esmodule", function (e) {
     if (e instanceof ESModuleEvent)
-        console.log("#esmodule", e, e.requestStatus);
+        console.log("#esmodule", e, e.requestState);
 });
 document.addEventListener("#action", function (e) {
     if (e instanceof ActionEvent)
@@ -14,7 +14,7 @@ document.addEventListener("#action", function (e) {
 });
 document.addEventListener("#json", function (e) {
     if (e instanceof JsonEvent)
-        console.log("#json", e, e.results);
+        console.log("#json", e, e.requestState);
 });
 document.addEventListener("#html", function (e) {
     if (e instanceof HtmlEvent)

--- a/examples/hypertext/mod.js
+++ b/examples/hypertext/mod.js
@@ -1,12 +1,12 @@
 import { SuperChunk, ActionEvent, HtmlEvent, JsonEvent, ESModuleEvent, } from "superchunk";
 const _superChunk = new SuperChunk({
-    host: document,
+    target: document,
     connected: true,
     eventNames: ["click", "pointerover"],
 });
 document.addEventListener("#esmodule", function (e) {
     if (e instanceof ESModuleEvent)
-        console.log("#esmodule", e, e.status);
+        console.log("#esmodule", e, e.requestStatus);
 });
 document.addEventListener("#action", function (e) {
     if (e instanceof ActionEvent)
@@ -14,7 +14,7 @@ document.addEventListener("#action", function (e) {
 });
 document.addEventListener("#json", function (e) {
     if (e instanceof JsonEvent)
-        console.log("#json", e, e.status);
+        console.log("#json", e, e.results);
 });
 document.addEventListener("#html", function (e) {
     if (e instanceof HtmlEvent)

--- a/examples/hypertext/mod.ts
+++ b/examples/hypertext/mod.ts
@@ -7,13 +7,13 @@ import {
 } from "superchunk";
 
 const _superChunk = new SuperChunk({
-	host: document,
+	target: document,
 	connected: true,
 	eventNames: ["click", "pointerover"],
 });
 
 document.addEventListener("#esmodule", function (e: Event) {
-	if (e instanceof ESModuleEvent) console.log("#esmodule", e, e.status);
+	if (e instanceof ESModuleEvent) console.log("#esmodule", e, e.requestStatus);
 });
 
 document.addEventListener("#action", function (e: Event) {
@@ -21,7 +21,7 @@ document.addEventListener("#action", function (e: Event) {
 });
 
 document.addEventListener("#json", function (e: Event) {
-	if (e instanceof JsonEvent) console.log("#json", e, e.status);
+	if (e instanceof JsonEvent) console.log("#json", e, e.results);
 });
 
 document.addEventListener("#html", function (e: Event) {

--- a/examples/hypertext/mod.ts
+++ b/examples/hypertext/mod.ts
@@ -13,7 +13,7 @@ const _superChunk = new SuperChunk({
 });
 
 document.addEventListener("#esmodule", function (e: Event) {
-	if (e instanceof ESModuleEvent) console.log("#esmodule", e, e.requestStatus);
+	if (e instanceof ESModuleEvent) console.log("#esmodule", e, e.requestState);
 });
 
 document.addEventListener("#action", function (e: Event) {
@@ -21,7 +21,7 @@ document.addEventListener("#action", function (e: Event) {
 });
 
 document.addEventListener("#json", function (e: Event) {
-	if (e instanceof JsonEvent) console.log("#json", e, e.results);
+	if (e instanceof JsonEvent) console.log("#json", e, e.requestState);
 });
 
 document.addEventListener("#html", function (e: Event) {

--- a/src/action_event.ts
+++ b/src/action_event.ts
@@ -1,5 +1,7 @@
 import type { DispatchParams } from "./type_flyweight.js";
 
+import { getQueueParams } from "./queue.js";
+
 import { getThrottleParams, setThrottler, shouldThrottle } from "./throttle.js";
 
 export interface ActionEventParamsInterface {

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -29,8 +29,8 @@ function dispatchEvent(params: DispatchParams) {
 	let attr = el.getAttribute(`${sourceEvent.type}:`);
 
 	if ("esmodule" === attr) return dispatchModuleImport(params);
-	if ("html" === attr) return dispatchHtmlEvent(params);
 	if ("json" === attr) return dispatchJsonEvent(params);
+	if ("html" === attr) return dispatchHtmlEvent(params);
 
 	return dispatchActionEvent(params);
 }

--- a/src/esmodule_event.ts
+++ b/src/esmodule_event.ts
@@ -6,13 +6,13 @@ const eventInitDict: EventInit = { bubbles: true, composed: true };
 
 // no union type needed
 
-export interface EsModuleEventErrorStatusInterface {
+interface EsModuleEventErrorStatusInterface {
 	status: "rejected";
 	url: string;
 	error: any;
 }
 
-export interface EsModuleEventResultsInterface {
+interface EsModuleEventResultsInterface {
 	status: "requested" | "resolved";
 	url: string;
 }
@@ -45,9 +45,10 @@ export function dispatchModuleImport(params: DispatchParams) {
 
 	let url = new URL(urlAttr, location.href).toString();
 	if (urlSet.has(url)) return;
-	urlSet.add(url);
 
+	urlSet.add(url);
 	dispatchEvent({ status: "requested", url });
+
 	import(url)
 		.then(function () {
 			dispatchEvent({ status: "resolved", url });

--- a/src/esmodule_event.ts
+++ b/src/esmodule_event.ts
@@ -16,10 +16,7 @@ export interface EsModuleEventInterface {
 export class ESModuleEvent extends Event implements EsModuleEventInterface {
 	results: EsModuleEventResultsInterface;
 
-	constructor(
-		results: EsModuleEventResultsInterface,
-		eventInitDict: EventInit,
-	) {
+	constructor(results: EsModuleEventResultsInterface, eventInitDict: EventInit) {
 		super("#esmodule", eventInitDict);
 		this.results = results;
 	}
@@ -35,14 +32,14 @@ export function dispatchModuleImport(params: DispatchParams) {
 	if (urlSet.has(url)) return;
 	urlSet.add(url);
 
-	dispatchEvent({ url, status: "requested" });
+	dispatchEvent({url, status: "requested"});
 	import(url)
 		.then(function () {
-			dispatchEvent({ url, status: "resolved" });
+			dispatchEvent({url, status: "resolved"});
 		})
 		.catch(function () {
 			urlSet.delete(url);
-			dispatchEvent({ url, status: "rejected" });
+			dispatchEvent({url, status: "rejected"});
 		});
 }
 

--- a/src/esmodule_event.ts
+++ b/src/esmodule_event.ts
@@ -4,24 +4,36 @@ let urlSet = new Set();
 
 const eventInitDict: EventInit = { bubbles: true, composed: true };
 
-export interface EsModuleEventResultsInterface {
+// no union type needed
+
+export interface EsModuleEventErrorStatusInterface {
+	status: "rejected";
 	url: string;
-	status: RequestStatus;
+	error: any;
 }
 
+export interface EsModuleEventResultsInterface {
+	status: "requested" | "resolved";
+	url: string;
+}
+
+export type EsModuleRequestStatusInterface =
+	| EsModuleEventResultsInterface
+	| EsModuleEventErrorStatusInterface;
+
 export interface EsModuleEventInterface {
-	results: EsModuleEventResultsInterface;
+	requestStatus: EsModuleRequestStatusInterface;
 }
 
 export class ESModuleEvent extends Event implements EsModuleEventInterface {
-	results: EsModuleEventResultsInterface;
+	requestStatus: EsModuleRequestStatusInterface;
 
 	constructor(
-		results: EsModuleEventResultsInterface,
+		requestStatus: EsModuleRequestStatusInterface,
 		eventInitDict: EventInit,
 	) {
 		super("#esmodule", eventInitDict);
-		this.results = results;
+		this.requestStatus = requestStatus;
 	}
 }
 
@@ -35,20 +47,18 @@ export function dispatchModuleImport(params: DispatchParams) {
 	if (urlSet.has(url)) return;
 	urlSet.add(url);
 
-	dispatchEvent({ url, status: "requested" });
+	dispatchEvent({ status: "requested", url });
 	import(url)
 		.then(function () {
-			dispatchEvent({ url, status: "resolved" });
+			dispatchEvent({ status: "resolved", url });
 		})
-		.catch(function () {
+		.catch(function (error: any) {
 			urlSet.delete(url);
-			dispatchEvent({ url, status: "rejected" });
+			dispatchEvent({ status: "rejected", url, error });
 		});
 }
 
-function dispatchEvent(results: EsModuleEventResultsInterface) {
-	let event = new ESModuleEvent(results, eventInitDict);
-
-	// only dispatch esmodule events from the document
+function dispatchEvent(status: EsModuleRequestStatusInterface) {
+	let event = new ESModuleEvent(status, eventInitDict);
 	document.dispatchEvent(event);
 }

--- a/src/esmodule_event.ts
+++ b/src/esmodule_event.ts
@@ -4,36 +4,40 @@ let urlSet = new Set();
 
 const eventInitDict: EventInit = { bubbles: true, composed: true };
 
-// no union type needed
-
-interface EsModuleEventErrorStatusInterface {
+interface EsModuleEventErrorStateInterface {
 	status: "rejected";
 	url: string;
 	error: any;
 }
 
-interface EsModuleEventResultsInterface {
-	status: "requested" | "resolved";
+interface EsModuleEventRequestedInterface {
+	status: "requested";
 	url: string;
 }
 
-export type EsModuleRequestStatusInterface =
-	| EsModuleEventResultsInterface
-	| EsModuleEventErrorStatusInterface;
+interface EsModuleEventResolvedInterface {
+	status: "resolved";
+	url: string;
+}
+
+export type EsModuleRequestState =
+	| EsModuleEventRequestedInterface
+	| EsModuleEventResolvedInterface
+	| EsModuleEventErrorStateInterface;
 
 export interface EsModuleEventInterface {
-	requestStatus: EsModuleRequestStatusInterface;
+	requestState: EsModuleRequestState;
 }
 
 export class ESModuleEvent extends Event implements EsModuleEventInterface {
-	requestStatus: EsModuleRequestStatusInterface;
+	requestState: EsModuleRequestState;
 
 	constructor(
-		requestStatus: EsModuleRequestStatusInterface,
+		requestState: EsModuleRequestState,
 		eventInitDict: EventInit,
 	) {
 		super("#esmodule", eventInitDict);
-		this.requestStatus = requestStatus;
+		this.requestState = requestState;
 	}
 }
 
@@ -59,7 +63,7 @@ export function dispatchModuleImport(params: DispatchParams) {
 		});
 }
 
-function dispatchEvent(status: EsModuleRequestStatusInterface) {
+function dispatchEvent(status: EsModuleRequestState) {
 	let event = new ESModuleEvent(status, eventInitDict);
 	document.dispatchEvent(event);
 }

--- a/src/esmodule_event.ts
+++ b/src/esmodule_event.ts
@@ -1,14 +1,4 @@
-import type { DispatchParams, RequestStatus } from "./type_flyweight.js";
-
-let urlSet = new Set();
-
-const eventInitDict: EventInit = { bubbles: true, composed: true };
-
-interface EsModuleEventErrorStateInterface {
-	status: "rejected";
-	url: string;
-	error: any;
-}
+import type { DispatchParams } from "./type_flyweight.js";
 
 interface EsModuleEventRequestedInterface {
 	status: "requested";
@@ -20,6 +10,12 @@ interface EsModuleEventResolvedInterface {
 	url: string;
 }
 
+interface EsModuleEventErrorStateInterface {
+	status: "rejected";
+	url: string;
+	error: any;
+}
+
 export type EsModuleRequestState =
 	| EsModuleEventRequestedInterface
 	| EsModuleEventResolvedInterface
@@ -29,13 +25,14 @@ export interface EsModuleEventInterface {
 	requestState: EsModuleRequestState;
 }
 
+let urlSet = new Set();
+
+const eventInitDict: EventInit = { bubbles: true, composed: true };
+
 export class ESModuleEvent extends Event implements EsModuleEventInterface {
 	requestState: EsModuleRequestState;
 
-	constructor(
-		requestState: EsModuleRequestState,
-		eventInitDict: EventInit,
-	) {
+	constructor(requestState: EsModuleRequestState, eventInitDict: EventInit) {
 		super("#esmodule", eventInitDict);
 		this.requestState = requestState;
 	}

--- a/src/esmodule_event.ts
+++ b/src/esmodule_event.ts
@@ -16,7 +16,10 @@ export interface EsModuleEventInterface {
 export class ESModuleEvent extends Event implements EsModuleEventInterface {
 	results: EsModuleEventResultsInterface;
 
-	constructor(results: EsModuleEventResultsInterface, eventInitDict: EventInit) {
+	constructor(
+		results: EsModuleEventResultsInterface,
+		eventInitDict: EventInit,
+	) {
 		super("#esmodule", eventInitDict);
 		this.results = results;
 	}
@@ -32,14 +35,14 @@ export function dispatchModuleImport(params: DispatchParams) {
 	if (urlSet.has(url)) return;
 	urlSet.add(url);
 
-	dispatchEvent({url, status: "requested"});
+	dispatchEvent({ url, status: "requested" });
 	import(url)
 		.then(function () {
-			dispatchEvent({url, status: "resolved"});
+			dispatchEvent({ url, status: "resolved" });
 		})
 		.catch(function () {
 			urlSet.delete(url);
-			dispatchEvent({url, status: "rejected"});
+			dispatchEvent({ url, status: "rejected" });
 		});
 }
 

--- a/src/html_event.ts
+++ b/src/html_event.ts
@@ -15,7 +15,7 @@ import type { Queuable, QueueNextCallback } from "./queue.js";
 
 import { getRequestParams } from "./type_flyweight.js";
 import { setThrottler, getThrottleParams, shouldThrottle } from "./throttle.js";
-import { shouldQueue, enqueue } from "./queue.js";
+import { getQueueParams, enqueue } from "./queue.js";
 
 export interface HtmlEventParamsInterface {
 	response: Response;
@@ -80,7 +80,7 @@ export function dispatchHtmlEvent(dispatchParams: DispatchParams) {
 			abortController,
 		);
 
-	let queueTarget = shouldQueue(dispatchParams);
+	let queueTarget = getQueueParams(dispatchParams);
 	if (queueTarget) {
 		let entry = new QueueableHtml(
 			dispatchParams,

--- a/src/html_event.ts
+++ b/src/html_event.ts
@@ -22,9 +22,6 @@ export interface HtmlEventParamsInterface {
 	html: string;
 	disconnected?: Element[];
 	connected?: Element[];
-	target?: Element;
-	destination?: Element;
-	projection?: string;
 }
 
 export interface HtmlEventInterface {
@@ -53,6 +50,18 @@ export class HtmlEvent extends Event {
 
 // status-target="match | querySelector | querySelectorAll" | default is querySelector
 // status-selector="selector" pending | completed
+
+// get html params implements throttle params
+
+/*
+	{
+		html as text,
+		fragment as DomFragment,
+		targetElements: Element[],
+		projection: "swap",
+		disconnected: [],
+	}
+*/
 
 export function dispatchHtmlEvent(dispatchParams: DispatchParams) {
 	let requestParams = getRequestParams(dispatchParams);

--- a/src/json_event.ts
+++ b/src/json_event.ts
@@ -29,15 +29,11 @@ export interface EsModuleEventInterface {
 }
 
 export class JsonEvent extends Event implements EsModuleEventInterface {
-	params: JsonEventParamsInterface;
+	results: JsonEventParamsInterface;
 
-	constructor(params: JsonEventParamsInterface, eventInit?: EventInit) {
+	constructor(results: JsonEventParamsInterface, eventInit?: EventInit) {
 		super("#json", eventInit);
-		this.params = params;
-	}
-
-	get results() {
-		return this.params;
+		this.results = results;
 	}
 }
 

--- a/src/json_event.ts
+++ b/src/json_event.ts
@@ -1,13 +1,13 @@
+import type { DispatchParams, RequestParams } from "./type_flyweight.js";
 import type {
-	DispatchParams,
-	RequestParams,
-	RequestStatus,
-} from "./type_flyweight.js";
-import type { Queuable, QueueNextCallback } from "./queue.js";
+	Queuable,
+	QueueNextCallback,
+	QueueParamsInterface,
+} from "./queue.js";
 
 import { getRequestParams } from "./type_flyweight.js";
 import { setThrottler, getThrottleParams, shouldThrottle } from "./throttle.js";
-import { shouldQueue, enqueue } from "./queue.js";
+import { getQueueParams, enqueue } from "./queue.js";
 
 const eventInitDict: EventInit = { bubbles: true, composed: true };
 
@@ -61,14 +61,15 @@ export function dispatchJsonEvent(dispatchParams: DispatchParams) {
 
 	setThrottler(dispatchParams, requestParams, throttleParams, abortController);
 
-	let queueTarget = shouldQueue(dispatchParams);
-	if (queueTarget) {
+	let queueParams = getQueueParams(dispatchParams);
+	if (queueParams) {
 		let entry = new QueueableJson(
 			dispatchParams,
 			requestParams,
+			queueParams,
 			abortController,
 		);
-		return enqueue(queueTarget, entry);
+		return enqueue(queueParams, entry);
 	}
 
 	fetchJson(dispatchParams, requestParams, abortController);
@@ -77,25 +78,35 @@ export function dispatchJsonEvent(dispatchParams: DispatchParams) {
 class QueueableJson implements Queuable {
 	#dispatchParams: DispatchParams;
 	#requestParams: RequestParams;
+	#queueParams: QueueParamsInterface;
 	#abortController: AbortController;
 
 	constructor(
 		dispatchParams: DispatchParams,
 		requestParams: RequestParams,
+		queueParams: QueueParamsInterface,
 		abortController: AbortController,
 	) {
 		this.#dispatchParams = dispatchParams;
 		this.#requestParams = requestParams;
+		this.#queueParams = queueParams;
 		this.#abortController = abortController;
 	}
 
 	dispatch(queueNextCallback: QueueNextCallback) {
-		fetchJson(
+		let { queueTarget } = this.#queueParams;
+
+		let promisedJson = fetchJson(
 			this.#dispatchParams,
 			this.#requestParams,
 			this.#abortController,
-			queueNextCallback,
-		);
+		)?.finally(function () {
+			queueNextCallback(queueTarget);
+		});
+
+		if (!promisedJson) {
+			queueNextCallback(queueTarget);
+		}
 	}
 }
 
@@ -103,51 +114,44 @@ function fetchJson(
 	params: DispatchParams,
 	requestParams: RequestParams,
 	abortController: AbortController,
-	queueNextCallback?: QueueNextCallback,
-) {
-	// el needs to be the designated queue target element?
-	let { el, currentTarget, formData } = params;
+): Promise<void> | undefined {
+	let { currentTarget, formData } = params;
 	let { url, action, timeoutMs, method } = requestParams;
 
-	if (abortController.signal.aborted || !url || !currentTarget) {
-		queueNextCallback?.(el);
-	} else {
-		let abortSignals = [abortController.signal];
-		if (timeoutMs) abortSignals.push(AbortSignal.timeout(timeoutMs));
+	if (abortController.signal.aborted || !url || !currentTarget) return;
 
-		let request = new Request(url, {
-			signal: AbortSignal.any(abortSignals),
-			method: method ?? "GET",
-			body: formData,
+	let abortSignals = [abortController.signal];
+	if (timeoutMs) abortSignals.push(AbortSignal.timeout(timeoutMs));
+
+	let request = new Request(url, {
+		signal: AbortSignal.any(abortSignals),
+		method: method ?? "GET",
+		body: formData,
+	});
+
+	let actionParams = { action, request, url };
+	let event = new JsonEvent(
+		{ status: "requested", ...actionParams },
+		eventInitDict,
+	);
+	currentTarget.dispatchEvent(event);
+
+	return fetch(request)
+		.then(resolveResponseBody)
+		.then(function ([response, json]) {
+			let event = new JsonEvent(
+				{ status: "resolved", response, json, ...actionParams },
+				eventInitDict,
+			);
+			currentTarget.dispatchEvent(event);
+		})
+		.catch(function (error: any) {
+			let event = new JsonEvent(
+				{ status: "rejected", error, ...actionParams },
+				eventInitDict,
+			);
+			currentTarget.dispatchEvent(event);
 		});
-
-		let actionParams = { action, request, url };
-		let event = new JsonEvent(
-			{ status: "requested", ...actionParams },
-			eventInitDict,
-		);
-		currentTarget.dispatchEvent(event);
-
-		fetch(request)
-			.then(resolveResponseBody)
-			.then(function ([response, json]) {
-				let event = new JsonEvent(
-					{ status: "resolved", response, json, ...actionParams },
-					eventInitDict,
-				);
-				currentTarget.dispatchEvent(event);
-			})
-			.catch(function (error: any) {
-				let event = new JsonEvent(
-					{ status: "rejected", error, ...actionParams },
-					eventInitDict,
-				);
-				currentTarget.dispatchEvent(event);
-			})
-			.finally(function () {
-				queueNextCallback?.(el);
-			});
-	}
 }
 
 function resolveResponseBody(response: Response): Promise<[Response, string]> {

--- a/src/json_event.ts
+++ b/src/json_event.ts
@@ -24,11 +24,11 @@ export interface JsonEventParamsInterface {
 	error?: any;
 }
 
-export interface EsModuleEventInterface {
+export interface JsonEventInterface {
 	results: JsonEventParamsInterface;
 }
 
-export class JsonEvent extends Event implements EsModuleEventInterface {
+export class JsonEvent extends Event implements JsonEventInterface {
 	results: JsonEventParamsInterface;
 
 	constructor(results: JsonEventParamsInterface, eventInit?: EventInit) {

--- a/src/json_event.ts
+++ b/src/json_event.ts
@@ -32,21 +32,21 @@ interface JsonEventRejectedInterface extends JsonEventParamsInterface {
 	error: any;
 }
 
-type JsonEventStates =
+type JsonEventState =
 	| JsonEventRejectedInterface
 	| JsonEventRequestedInterface
 	| JsonEventResolvedInterface;
 
 export interface JsonEventInterface {
-	results: JsonEventStates;
+	requestState: JsonEventState;
 }
 
 export class JsonEvent extends Event implements JsonEventInterface {
-	results: JsonEventStates;
+	requestState: JsonEventState;
 
-	constructor(results: JsonEventStates, eventInitDict?: EventInit) {
+	constructor(requestState: JsonEventState, eventInitDict?: EventInit) {
 		super("#json", eventInitDict);
-		this.results = results;
+		this.requestState = requestState;
 	}
 }
 

--- a/src/json_event.ts
+++ b/src/json_event.ts
@@ -17,17 +17,17 @@ interface JsonEventParamsInterface {
 	action: string | null;
 }
 
-interface JsonEventRequestedInterface {
+interface JsonEventRequestedInterface extends JsonEventParamsInterface {
 	status: "requested";
 }
 
-interface JsonEventResolvedInterface {
+interface JsonEventResolvedInterface extends JsonEventParamsInterface {
 	status: "resolved";
 	response: Response;
 	json: any;
 }
 
-interface JsonEventRejectedInterface {
+interface JsonEventRejectedInterface extends JsonEventParamsInterface {
 	status: "rejected";
 	error: any;
 }
@@ -42,16 +42,10 @@ export interface JsonEventInterface {
 }
 
 export class JsonEvent extends Event implements JsonEventInterface {
-	params: JsonEventParamsInterface;
 	results: JsonEventStates;
 
-	constructor(
-		params: JsonEventParamsInterface,
-		results: JsonEventStates,
-		eventInitDict?: EventInit,
-	) {
+	constructor(results: JsonEventStates, eventInitDict?: EventInit) {
 		super("#json", eventInitDict);
-		this.params = params;
 		this.results = results;
 	}
 }
@@ -111,6 +105,7 @@ function fetchJson(
 	abortController: AbortController,
 	queueNextCallback?: QueueNextCallback,
 ) {
+	// el needs to be the designated queue target element?
 	let { el, currentTarget, formData } = params;
 	let { url, action, timeoutMs, method } = requestParams;
 
@@ -128,8 +123,7 @@ function fetchJson(
 
 		let actionParams = { action, request, url };
 		let event = new JsonEvent(
-			actionParams,
-			{ status: "requested" },
+			{ status: "requested", ...actionParams },
 			eventInitDict,
 		);
 		currentTarget.dispatchEvent(event);
@@ -138,16 +132,14 @@ function fetchJson(
 			.then(resolveResponseBody)
 			.then(function ([response, json]) {
 				let event = new JsonEvent(
-					actionParams,
-					{ status: "resolved", response, json },
+					{ status: "resolved", response, json, ...actionParams },
 					eventInitDict,
 				);
 				currentTarget.dispatchEvent(event);
 			})
 			.catch(function (error: any) {
 				let event = new JsonEvent(
-					actionParams,
-					{ status: "rejected", error },
+					{ status: "rejected", error, ...actionParams },
 					eventInitDict,
 				);
 				currentTarget.dispatchEvent(event);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,7 @@ export { HtmlEvent } from "./html_event.js";
 import { dispatch } from "./dispatch.js";
 
 export interface SuperChunkParamsInterface {
-	host: ParentNode;
+	target: ParentNode;
 	eventNames: string[];
 	connected?: boolean;
 }
@@ -25,18 +25,18 @@ export class SuperChunk {
 	}
 
 	connect() {
-		let { host, eventNames } = this.#params;
+		let { target, eventNames } = this.#params;
 
 		for (let name of eventNames) {
-			host.addEventListener(name, dispatch);
+			target.addEventListener(name, dispatch);
 		}
 	}
 
 	disconnect() {
-		let { host, eventNames } = this.#params;
+		let { target, eventNames } = this.#params;
 
 		for (let name of eventNames) {
-			host.removeEventListener(name, dispatch);
+			target.removeEventListener(name, dispatch);
 		}
 	}
 }

--- a/src/throttle.ts
+++ b/src/throttle.ts
@@ -11,7 +11,7 @@ interface ThrottleParams {
 	timeoutMs: number;
 }
 
-interface ThrottleRequestParams {
+export interface ThrottleRequestParams {
 	url?: ReturnType<Element["getAttribute"]>;
 	action?: ReturnType<Element["getAttribute"]>;
 }

--- a/src/type_flyweight.ts
+++ b/src/type_flyweight.ts
@@ -10,9 +10,9 @@ export interface ActionParams {
 }
 
 export interface RequestParams extends ActionParams {
-	action?: ReturnType<Element["getAttribute"]>;
-	url?: ReturnType<Element["getAttribute"]>;
-	method?: ReturnType<Element["getAttribute"]>;
+	action: ReturnType<Element["getAttribute"]>;
+	url: ReturnType<Element["getAttribute"]>;
+	method: ReturnType<Element["getAttribute"]>;
 	timeoutMs?: number;
 }
 


### PR DESCRIPTION
Added request state for JSON events.

Return promises in request functions. For example, fetchJson returns a promise instead of passing a callback in arguments.

Add "finally" to the tail end of returned promises.